### PR TITLE
Improve LSM6DSO drivers

### DIFF
--- a/src/main/drivers/accgyro/accgyro_spi_lsm6dso.c
+++ b/src/main/drivers/accgyro/accgyro_spi_lsm6dso.c
@@ -20,6 +20,8 @@
 
 #include <stdbool.h>
 #include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
 
 #include "platform.h"
 
@@ -31,8 +33,48 @@
 #include "drivers/exti.h"
 #include "drivers/io.h"
 #include "drivers/io_impl.h"
+#include "drivers/nvic.h"
+#include "drivers/sensor.h"
+#include "drivers/system.h"
+#include "drivers/time.h"
 
-#if defined(USE_GYRO_EXTI) && defined(USE_MPU_DATA_READY_SIGNAL)
+// Need to see at least this many interrupts during initialisation to confirm EXTI connectivity
+#define GYRO_EXTI_DETECT_THRESHOLD 1000
+
+#ifdef USE_GYRO_EXTI
+// Called in ISR context
+// Gyro read has just completed
+busStatus_e lsm6dsoIntcallback(uint32_t arg)
+{
+    gyroDev_t *gyro = (gyroDev_t *)arg;
+    int32_t gyroDmaDuration = cmpTimeCycles(getCycleCounter(), gyro->gyroLastEXTI);
+
+    if (gyroDmaDuration > gyro->gyroDmaMaxDuration) {
+        gyro->gyroDmaMaxDuration = gyroDmaDuration;
+    }
+
+    gyro->dataReady = true;
+
+    return BUS_READY;
+}
+
+void lsm6dsoExtiHandler(extiCallbackRec_t *cb)
+{
+    gyroDev_t *gyro = container_of(cb, gyroDev_t, exti);
+    // Ideally we'd use a timer to capture such information, but unfortunately the port used for EXTI interrupt does
+    // not have an associated timer
+    uint32_t nowCycles = getCycleCounter();
+    gyro->gyroSyncEXTI = gyro->gyroLastEXTI + gyro->gyroDmaMaxDuration;
+    gyro->gyroLastEXTI = nowCycles;
+
+    if (gyro->gyroModeSPI == GYRO_EXTI_INT_DMA) {
+        spiSequence(&gyro->dev, gyro->segments);
+    }
+
+    gyro->detectedEXTI++;
+
+}
+#else
 void lsm6dsoExtiHandler(extiCallbackRec_t *cb)
 {
     gyroDev_t *gyro = container_of(cb, gyroDev_t, exti);
@@ -42,48 +84,122 @@ void lsm6dsoExtiHandler(extiCallbackRec_t *cb)
 
 bool lsm6dsoAccRead(accDev_t *acc)
 {
-    enum {
-        IDX_ACCEL_XOUT_L,
-        IDX_ACCEL_XOUT_H,
-        IDX_ACCEL_YOUT_L,
-        IDX_ACCEL_YOUT_H,
-        IDX_ACCEL_ZOUT_L,
-        IDX_ACCEL_ZOUT_H,
-        BUFFER_SIZE,
-    };
+    switch (acc->gyro->gyroModeSPI) {
+    case GYRO_EXTI_INT:
+    case GYRO_EXTI_NO_INT:
+    {
+        acc->gyro->dev.txBuf[0] = LSM6DSO_REG_OUTX_L_A | 0x80;
 
-    uint8_t lsm6dso_rx_buf[BUFFER_SIZE];
+        busSegment_t segments[] = {
+                {.u.buffers = {NULL, NULL}, 7, true, NULL},
+                {.u.link = {NULL, NULL}, 0, true, NULL},
+        };
+        segments[0].u.buffers.txData = &acc->gyro->dev.txBuf[1];
+        segments[0].u.buffers.rxData = &acc->gyro->dev.rxBuf[1];
 
-    extDevice_t *dev = &acc->gyro->dev;
-    busReadRegisterBuffer(dev, LSM6DSO_REG_OUTX_L_A, lsm6dso_rx_buf, BUFFER_SIZE);
+        spiSequence(&acc->gyro->dev, &segments[0]);
 
-    acc->ADCRaw[X] = (int16_t)((lsm6dso_rx_buf[IDX_ACCEL_XOUT_H] << 8) | lsm6dso_rx_buf[IDX_ACCEL_XOUT_L]);
-    acc->ADCRaw[Y] = (int16_t)((lsm6dso_rx_buf[IDX_ACCEL_YOUT_H] << 8) | lsm6dso_rx_buf[IDX_ACCEL_YOUT_L]);
-    acc->ADCRaw[Z] = (int16_t)((lsm6dso_rx_buf[IDX_ACCEL_ZOUT_H] << 8) | lsm6dso_rx_buf[IDX_ACCEL_ZOUT_L]);
+        // Wait for completion
+        spiWait(&acc->gyro->dev);
+
+        uint16_t *accData = (uint16_t *)acc->gyro->dev.rxBuf;
+        acc->ADCRaw[X] = accData[1];
+        acc->ADCRaw[Y] = accData[2];
+        acc->ADCRaw[Z] = accData[3];
+        break;  
+    }
+
+    case GYRO_EXTI_INT_DMA:
+    {
+        // If read was triggered in interrupt don't bother waiting. The worst that could happen is that we pick
+        // up an old value.
+
+        // This data was read from the gyro, which is the same SPI device as the acc
+        uint16_t *accData = (uint16_t *)acc->gyro->dev.rxBuf;
+        acc->ADCRaw[X] = accData[4];
+        acc->ADCRaw[Y] = accData[5];
+        acc->ADCRaw[Z] = accData[6];
+        break;
+    }
+
+    case GYRO_EXTI_INIT:
+    default:
+        break;
+    }
 
     return true;
 }
 
 bool lsm6dsoGyroRead(gyroDev_t *gyro)
 {
-    enum {
-        IDX_GYRO_XOUT_L,
-        IDX_GYRO_XOUT_H,
-        IDX_GYRO_YOUT_L,
-        IDX_GYRO_YOUT_H,
-        IDX_GYRO_ZOUT_L,
-        IDX_GYRO_ZOUT_H,
-        BUFFER_SIZE,
-    };
+    uint16_t *gyroData = (uint16_t *)gyro->dev.rxBuf;
+    switch (gyro->gyroModeSPI) {
+    case GYRO_EXTI_INIT:
+    {
+        // Initialise the tx buffer to all 0x00
+        memset(gyro->dev.txBuf, 0x00, 14);
+#ifdef USE_GYRO_EXTI
+        // Check that minimum number of interrupts have been detected
 
-    uint8_t lsm6dso_rx_buf[BUFFER_SIZE];
+        // We need some offset from the gyro interrupts to ensure sampling after the interrupt
+        gyro->gyroDmaMaxDuration = 5;
+        // Using DMA for gyro access upsets the scheduler on the F4
+        if (gyro->detectedEXTI > GYRO_EXTI_DETECT_THRESHOLD) {
+            if (spiUseDMA(&gyro->dev)) {
+                gyro->dev.callbackArg = (uint32_t)gyro;
+                gyro->dev.txBuf[1] = LSM6DSO_REG_OUTX_L_G | 0x80;
+                gyro->segments[0].len = 14;
+                gyro->segments[0].callback = lsm6dsoIntcallback;
+                gyro->segments[0].u.buffers.txData = &gyro->dev.txBuf[1];
+                gyro->segments[0].u.buffers.rxData = &gyro->dev.rxBuf[1];
+                gyro->segments[0].negateCS = true;
+                gyro->gyroModeSPI = GYRO_EXTI_INT_DMA;
+            } else {
+                // Interrupts are present, but no DMA
+                gyro->gyroModeSPI = GYRO_EXTI_INT;
+            }
+        } else
+#endif
+        {
+            gyro->gyroModeSPI = GYRO_EXTI_NO_INT;
+        }
+        break;
+    }
 
-    extDevice_t *dev = &gyro->dev;
-    busReadRegisterBuffer(dev, LSM6DSO_REG_OUTX_L_G, lsm6dso_rx_buf, BUFFER_SIZE);
+    case GYRO_EXTI_INT:
+    case GYRO_EXTI_NO_INT:
+    {
+        gyro->dev.txBuf[1] = LSM6DSO_REG_OUTX_L_G | 0x80;
 
-    gyro->gyroADCRaw[X] = (int16_t)((lsm6dso_rx_buf[IDX_GYRO_XOUT_H] << 8) | lsm6dso_rx_buf[IDX_GYRO_XOUT_L]);
-    gyro->gyroADCRaw[Y] = (int16_t)((lsm6dso_rx_buf[IDX_GYRO_YOUT_H] << 8) | lsm6dso_rx_buf[IDX_GYRO_YOUT_L]);
-    gyro->gyroADCRaw[Z] = (int16_t)((lsm6dso_rx_buf[IDX_GYRO_ZOUT_H] << 8) | lsm6dso_rx_buf[IDX_GYRO_ZOUT_L]);
+        busSegment_t segments[] = {
+                {.u.buffers = {NULL, NULL}, 7, true, NULL},
+                {.u.link = {NULL, NULL}, 0, true, NULL},
+        };
+        segments[0].u.buffers.txData = &gyro->dev.txBuf[1];
+        segments[0].u.buffers.rxData = &gyro->dev.rxBuf[1];
+
+        spiSequence(&gyro->dev, &segments[0]);
+
+        // Wait for completion
+        spiWait(&gyro->dev);
+
+        // Fall through
+        FALLTHROUGH;
+    }
+
+    case GYRO_EXTI_INT_DMA:
+    {
+        // If read was triggered in interrupt don't bother waiting. The worst that could happen is that we pick
+        // up an old value.
+        gyro->gyroADCRaw[X] = gyroData[1];
+        gyro->gyroADCRaw[Y] = gyroData[2];
+        gyro->gyroADCRaw[Z] = gyroData[3];
+        break;
+    }
+
+    default:
+        break;
+    }
 
     return true;
 }

--- a/src/main/drivers/accgyro/accgyro_spi_lsm6dso_init.c
+++ b/src/main/drivers/accgyro/accgyro_spi_lsm6dso_init.c
@@ -20,6 +20,8 @@
 
 #include <stdbool.h>
 #include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
 
 #include "platform.h"
 
@@ -33,6 +35,7 @@
 #include "drivers/io_impl.h"
 #include "drivers/nvic.h"
 #include "drivers/sensor.h"
+#include "drivers/system.h"
 #include "drivers/time.h"
 
 // 10 MHz max SPI frequency
@@ -147,7 +150,7 @@ static void lsm6dsoConfig(gyroDev_t *gyro)
     lsm6dsoWriteRegisterBits(dev, LSM6DSO_REG_CTRL9_XL, LSM6DSO_MASK_CTRL9_XL, LSM6DSO_VAL_CTRL9_XL_I3C_DISABLE, 1);
 }
 
-#if defined(USE_GYRO_EXTI) && defined(USE_MPU_DATA_READY_SIGNAL)
+#ifdef USE_GYRO_EXTI
 static void lsm6dsoIntExtiInit(gyroDev_t *gyro)
 {
     if (gyro->mpuIntExtiTag == IO_TAG_NONE) {
@@ -169,7 +172,7 @@ static void lsm6dsoSpiGyroInit(gyroDev_t *gyro)
 
     lsm6dsoConfig(gyro);
 
-#if defined(USE_GYRO_EXTI) && defined(USE_MPU_DATA_READY_SIGNAL)
+#ifdef USE_GYRO_EXTI
     lsm6dsoIntExtiInit(gyro);
 #endif
 

--- a/src/main/drivers/accgyro/accgyro_spi_lsm6dso_init.c
+++ b/src/main/drivers/accgyro/accgyro_spi_lsm6dso_init.c
@@ -38,6 +38,8 @@
 #include "drivers/system.h"
 #include "drivers/time.h"
 
+#include "sensors/gyro.h"
+
 // 10 MHz max SPI frequency
 #define LSM6DSO_MAX_SPI_CLK_HZ 10000000
 
@@ -112,6 +114,21 @@ static void lsm6dsoWriteRegisterBits(const extDevice_t *dev, lsm6dsoRegister_e r
     }
 }
 
+static uint8_t getLsmDlpfBandwidth()
+{
+    switch(gyroConfig()->gyro_hardware_lpf) {
+        case GYRO_HARDWARE_LPF_NORMAL:
+            return LSM6DSO_VAL_CTRL6_C_FTYPE_232HZ;
+        case GYRO_HARDWARE_LPF_OPTION_1:
+            return LSM6DSO_VAL_CTRL6_C_FTYPE_335HZ;
+        case GYRO_HARDWARE_LPF_OPTION_2:
+            return LSM6DSO_VAL_CTRL6_C_FTYPE_609HZ;
+        case GYRO_HARDWARE_LPF_EXPERIMENTAL:
+            return LSM6DSO_VAL_CTRL6_C_FTYPE_609HZ;
+    }
+    return 0;
+}
+
 static void lsm6dsoConfig(gyroDev_t *gyro)
 {
     extDevice_t *dev = &gyro->dev;
@@ -143,7 +160,7 @@ static void lsm6dsoConfig(gyroDev_t *gyro)
 
     // Configure control register 6
     // disable I2C interface; enable gyro LPF1
-    lsm6dsoWriteRegisterBits(dev, LSM6DSO_REG_CTRL6_C, LSM6DSO_MASK_CTRL6_C, (LSM6DSO_VAL_CTRL6_C_XL_HM_MODE | LSM6DSO_VAL_CTRL6_C_FTYPE_335HZ), 1);
+    lsm6dsoWriteRegisterBits(dev, LSM6DSO_REG_CTRL6_C, LSM6DSO_MASK_CTRL6_C, (LSM6DSO_VAL_CTRL6_C_XL_HM_MODE | getLsmDlpfBandwidth()), 1);
 
     // Configure control register 9
     // disable I3C interface

--- a/src/main/drivers/accgyro/accgyro_spi_lsm6dso_init.c
+++ b/src/main/drivers/accgyro/accgyro_spi_lsm6dso_init.c
@@ -67,10 +67,15 @@ typedef enum {
     LSM6DSO_VAL_CTRL4_C_I2C_DISABLE = BIT(2), // (bit 2) disable I2C interface
     LSM6DSO_VAL_CTRL4_C_LPF1_SEL_G = BIT(1),  // (bit 1) enable gyro LPF1
     LSM6DSO_VAL_CTRL6_C_XL_HM_MODE = 0,       // (bit 4) enable accelerometer high performance mode
-    LSM6DSO_VAL_CTRL6_C_FTYPE_335HZ = 0x00,   // (bits 2:0) gyro LPF1 cutoff 335.5hz
-    LSM6DSO_VAL_CTRL6_C_FTYPE_232HZ = 0x01,   // (bits 2:0) gyro LPF1 cutoff 232.0hz
-    LSM6DSO_VAL_CTRL6_C_FTYPE_171HZ = 0x02,   // (bits 2:0) gyro LPF1 cutoff 171.1hz
-    LSM6DSO_VAL_CTRL6_C_FTYPE_609HZ = 0x03,   // (bits 2:0) gyro LPF1 cutoff 609.0hz
+    LSM6DSO_VAL_CTRL6_C_FTYPE_335HZ = 0x00,   // (bits 2:0) gyro LPF1 cutoff 335.5Hz
+    LSM6DSO_VAL_CTRL6_C_FTYPE_232HZ = 0x01,   // (bits 2:0) gyro LPF1 cutoff 232.0Hz
+    LSM6DSO_VAL_CTRL6_C_FTYPE_171HZ = 0x02,   // (bits 2:0) gyro LPF1 cutoff 171.1Hz
+    LSM6DSO_VAL_CTRL6_C_FTYPE_609HZ = 0x03,   // (bits 2:0) gyro LPF1 cutoff 609.0Hz
+    LSM6DSO_VAL_CTRL7_G_HP_EN_G = BIT(6),   // (bit 6) enable gyro high-pass filter
+    LSM6DSO_VAL_CTRL7_G_HPM_G_16 = 0x00,      // (bits 5:4) gyro HPF cutoff 16mHz
+    LSM6DSO_VAL_CTRL7_G_HPM_G_65 = 0x01,      // (bits 5:4) gyro HPF cutoff 65mHz
+    LSM6DSO_VAL_CTRL7_G_HPM_G_260 = 0x02,     // (bits 5:4) gyro HPF cutoff 260mHz
+    LSM6DSO_VAL_CTRL7_G_HPM_G_1040 = 0x03,    // (bits 5:4) gyro HPF cutoff 1.04Hz
     LSM6DSO_VAL_CTRL9_XL_I3C_DISABLE = BIT(1),// (bit 1) disable I3C interface
 } lsm6dsoConfigValues_e;
 
@@ -80,6 +85,7 @@ typedef enum {
     LSM6DSO_MASK_CTRL3_C_RESET = BIT(0), // 0b00000001
     LSM6DSO_MASK_CTRL4_C = 0x06,         // 0b00000110
     LSM6DSO_MASK_CTRL6_C = 0x17,         // 0b00010111
+    LSM6DSO_MASK_CTRL7_G = 0x70,         // 0b01110000
     LSM6DSO_MASK_CTRL9_XL = 0x02,        // 0b00000010
 } lsm6dsoConfigMasks_e;
 
@@ -161,6 +167,9 @@ static void lsm6dsoConfig(gyroDev_t *gyro)
     // Configure control register 6
     // disable I2C interface; enable gyro LPF1
     lsm6dsoWriteRegisterBits(dev, LSM6DSO_REG_CTRL6_C, LSM6DSO_MASK_CTRL6_C, (LSM6DSO_VAL_CTRL6_C_XL_HM_MODE | getLsmDlpfBandwidth()), 1);
+
+    // Configure control register 7
+    lsm6dsoWriteRegisterBits(dev, LSM6DSO_REG_CTRL7_G, LSM6DSO_MASK_CTRL7_G, (LSM6DSO_VAL_CTRL7_G_HP_EN_G | LSM6DSO_VAL_CTRL7_G_HPM_G_16), 1);
 
     // Configure control register 9
     // disable I3C interface


### PR DESCRIPTION
- [x] Added SPI DMA support
- [x] Added gyro (IMU's built-in hardware) LPF1 selector, inspired by bmi's OSRx mode selector. 
  - NORMAL = 232Hz
  - Option_1 = 335Hz
  - Option_2 = Experimental = 609Hz
- [x] Added gyro (IMU's built-in hardware) HPF settings, and
- [x] Enabled  gyro (IMU's built-in hardware) HPF with 16mHz cutoff
